### PR TITLE
remove nvtop (cuda dependency)

### DIFF
--- a/home-manager/profiles/desktop.nix
+++ b/home-manager/profiles/desktop.nix
@@ -53,10 +53,6 @@
         karere
         # cooked ahh notation
         zen-browser.packages.${stdenv.hostPlatform.system}.default
-      ]
-      # only install these packages on x86_64-linux systems
-      ++ lib.optionals (system-config.nixpkgs.hostPlatform.isx86_64) [
-        nvtopPackages.full
       ];
   };
 }


### PR DESCRIPTION
Cuda is unfree software that takes forever to build. You also not need this at all.