### PR TITLE
fix openldap

### DIFF
--- a/modules/gaming/default.nix
+++ b/modules/gaming/default.nix
@@ -13,6 +13,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # fix for nixpkgs#513245
+    nixpkgs.overlays = [
+      (_: prev: {
+        openldap = prev.openldap.overrideAttrs {
+          # tests failing? just ignore them lmao
+          doCheck = !prev.stdenv.hostPlatform.isi686;
+        };
+      })
+    ];
+
     programs.steam.enable = true;
     environment.systemPackages = with pkgs; [
       (lutris.override {


### PR DESCRIPTION
Some tests fail for 32-bit openldap. It's a dependency for lutris.